### PR TITLE
Fix percentage calculation

### DIFF
--- a/lib/feature/stocks/presentation/stock_ui.dart
+++ b/lib/feature/stocks/presentation/stock_ui.dart
@@ -34,7 +34,8 @@ class StockUi extends Equatable {
       );
 
   static int getPercentageChange(StockEntity stockEntity) {
-    return (((stockEntity.close! - stockEntity.open!) / 100) * 100).toInt();
+    return (((stockEntity.close! - stockEntity.open!) / stockEntity.open!) * 100)
+        .toInt();
   }
 
   static String formatDate(String date) {

--- a/test/stocks/stock_ui_test.dart
+++ b/test/stocks/stock_ui_test.dart
@@ -1,0 +1,10 @@
+import 'package:bstock/core/database/models/stock_entity.dart';
+import 'package:bstock/feature/stocks/presentation/stock_ui.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('getPercentageChange returns correct value', () {
+    final stock = StockEntity(open: 100.0, close: 150.0);
+    expect(StockUi.getPercentageChange(stock), 50);
+  });
+}


### PR DESCRIPTION
## Summary
- fix percent change calculation in StockUi
- add a unit test for StockUi.getPercentageChange

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850e6a4520c83228fdf51a9408c3d2b