### PR TITLE
Add widget and unit tests

### DIFF
--- a/test/add_select_company/company_widget_test.dart
+++ b/test/add_select_company/company_widget_test.dart
@@ -1,0 +1,19 @@
+import 'package:bstock/core/database/models/company.dart';
+import 'package:bstock/feature/add_select_company/add_select_company_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CompanyWidget displays name and symbol', (tester) async {
+    final company = Company(name: 'Test', symbol: 'TST', selected: true);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: CompanyWidget(company: company),
+      ),
+    ));
+
+    expect(find.text('Test'), findsOneWidget);
+    expect(find.text('TST'), findsOneWidget);
+  });
+}

--- a/test/company/company_cubit_test.dart
+++ b/test/company/company_cubit_test.dart
@@ -1,0 +1,37 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:bstock/core/company/domain/company_repository.dart';
+import 'package:bstock/core/company/presentation/company_cubit.dart';
+import 'package:bstock/core/database/models/company.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'company_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<CompanyRepository>()])
+void main() {
+  group('CompanyCubit', () {
+    late MockCompanyRepository repository;
+    late CompanyCubit cubit;
+
+    setUp(() {
+      repository = MockCompanyRepository();
+      cubit = CompanyCubit(repository);
+    });
+
+    tearDown(() {
+      cubit.close();
+    });
+
+    blocTest<CompanyCubit, List<Company>>(
+      'emits companies when fetchCompanies succeeds',
+      build: () {
+        when(repository.fetchCompanies())
+            .thenAnswer((_) async => Company.getDefaultCompanies());
+        return cubit;
+      },
+      act: (c) => c.fetchCompanies(),
+      expect: () => [Company.getDefaultCompanies()],
+    );
+  });
+}

--- a/test/network/api_provider_test.dart
+++ b/test/network/api_provider_test.dart
@@ -1,0 +1,44 @@
+import 'package:bstock/core/network/api_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'api_provider_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Dio>()])
+void main() {
+  group('ApiProvider', () {
+    late MockDio mockDio;
+    late ApiProvider apiProvider;
+
+    setUp(() {
+      mockDio = MockDio();
+      apiProvider = ApiProvider(mockDio);
+    });
+
+    test('returns data when request succeeds', () async {
+      final response = Response(
+        requestOptions: RequestOptions(path: '/test'),
+        data: {'result': 'ok'},
+      );
+
+      when(mockDio.get<dynamic>('/test', queryParameters: anyNamed('queryParameters')))
+          .thenAnswer((_) async => response);
+
+      final result = await apiProvider.get('/test', {});
+      expect(result, {'result': 'ok'});
+    });
+
+    test('throws message when DioException occurs', () async {
+      final exception = DioException(
+        requestOptions: RequestOptions(path: '/test'),
+        message: 'error',
+      );
+      when(mockDio.get<dynamic>('/test', queryParameters: anyNamed('queryParameters')))
+          .thenThrow(exception);
+
+      expect(() => apiProvider.get('/test', {}), throwsA('error'));
+    });
+  });
+}

--- a/test/stocks/stock_ui_test.dart
+++ b/test/stocks/stock_ui_test.dart
@@ -1,0 +1,17 @@
+import 'package:bstock/feature/stocks/presentation/stock_ui.dart';
+import 'package:bstock/core/database/models/stock_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StockUi helper methods', () {
+    test('getPercentageChange returns correct difference', () {
+      const entity = StockEntity(open: 100, close: 150);
+      expect(StockUi.getPercentageChange(entity), 50);
+    });
+
+    test('formatDate returns formatted date', () {
+      const date = '2023-07-27T00:00:00Z';
+      expect(StockUi.formatDate(date), '27 Jul, 2023');
+    });
+  });
+}

--- a/test/widgets/app_error_widget_test.dart
+++ b/test/widgets/app_error_widget_test.dart
@@ -1,0 +1,14 @@
+import 'package:bstock/core/widgets/app_error_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AppErrorWidget displays error text', (tester) async {
+    const errorMessage = 'An error occurred';
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: AppErrorWidget(error: errorMessage)),
+    ));
+
+    expect(find.text(errorMessage), findsOneWidget);
+  });
+}

--- a/test/widgets/app_textfield_test.dart
+++ b/test/widgets/app_textfield_test.dart
@@ -1,0 +1,11 @@
+import 'package:bstock/core/widgets/app_textfield.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('buildInputDecoration sets hint text', () {
+    const hint = 'Search';
+    final decoration = buildInputDecoration(hint);
+    expect(decoration.hintText, hint);
+  });
+}

--- a/test/widgets/high_low_stock_widget_test.dart
+++ b/test/widgets/high_low_stock_widget_test.dart
@@ -1,0 +1,37 @@
+import 'package:bstock/feature/stocks/presentation/widgets/highest_lowest_stock_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('HighLowStockWidget highest displays green value', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: HighLowStockWidget(
+          value: '120',
+          company: 'Apple, AAPL',
+          stockStatus: StockStatus.highest,
+        ),
+      ),
+    ));
+
+    final text = tester.widget<Text>(find.text('120'));
+    expect(text.style?.color, Colors.green);
+    expect(find.text('HIGHEST'), findsOneWidget);
+  });
+
+  testWidgets('HighLowStockWidget lowest displays red value', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: HighLowStockWidget(
+          value: '80',
+          company: 'Apple, AAPL',
+          stockStatus: StockStatus.lowest,
+        ),
+      ),
+    ));
+
+    final text = tester.widget<Text>(find.text('80'));
+    expect(text.style?.color, Colors.red);
+    expect(find.text('LOWEST'), findsOneWidget);
+  });
+}

--- a/test/widgets/loading_widget_test.dart
+++ b/test/widgets/loading_widget_test.dart
@@ -1,0 +1,13 @@
+import 'package:bstock/feature/stocks/presentation/widgets/loading_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('LoadingWidget shows CircularProgressIndicator', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: LoadingWidget()),
+    ));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/test/widgets/stock_item_widget_test.dart
+++ b/test/widgets/stock_item_widget_test.dart
@@ -1,0 +1,25 @@
+import 'package:bstock/core/database/models/stock_entity.dart';
+import 'package:bstock/feature/stocks/presentation/widgets/stock_item_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('StockItemWidget shows gain indicator for positive change', (tester) async {
+    const stock = StockEntity(
+      open: 100,
+      close: 150,
+      date: '2023-07-27T00:00:00Z',
+      symbol: 'AAPL',
+      company: 'Apple',
+    );
+
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: StockItemWidget(stock: stock)),
+    ));
+
+    expect(find.byIcon(Icons.arrow_drop_up), findsOneWidget);
+    final percentageText = tester.widget<Text>(find.text('50%'));
+    expect(percentageText.style?.color, Colors.green);
+    expect(find.text('As at 27 Jul, 2023'), findsOneWidget);
+  });
+}

--- a/test/widgets/stock_page_title_test.dart
+++ b/test/widgets/stock_page_title_test.dart
@@ -1,0 +1,13 @@
+import 'package:bstock/feature/stocks/presentation/widgets/stock_page_title.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('StocksTitleWidget renders title', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: StocksTitleWidget()),
+    ));
+
+    expect(find.textContaining('Portfolio'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add CompanyCubit tests
- test helpers in StockUi
- test AppErrorWidget and LoadingWidget
- test CompanyWidget rendering
- add ApiProvider and widget tests

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850e86b38388322afe86a28904f12ad